### PR TITLE
Make choose.dir.windows(default="<path>") actually do what it should

### DIFF
--- a/inst/utils/newFolderDialog.ps1
+++ b/inst/utils/newFolderDialog.ps1
@@ -183,7 +183,7 @@ Add-Type  -ReferencedAssemblies $Assem -TypeDefinition $BuildDialog -ErrorAction
 
 $fsd = New-Object FolderSelect.FolderSelectDialog
     $fsd.Title = $caption;
-    $fsd.InitialDirectory = $default
+    $fsd.InitialDirectory = $default.Trim('"')
     $fsd.ShowDialog() | Out-Null
 
 $fsd.FileName


### PR DESCRIPTION
`?choose.dir` indicates that the `default=` argument allows the user to indicate the folder in which the selection dialog should open. A couple of quick checks should be enough to convince one that it does not actually work:

```r
choose.dir("C:/Users")
choose.dir("C:/Program Files")
```

The problem is that, as documented in its next to final line, the PowerShell script called by `choose.dir.windows()` expects an unquoted file path:

```
# usage: powershell -NoProfile -ExecutionPolicy Bypass -File newFolderDialog.ps1 -caption test -default c:\Users
```

`choose.dir.windows()`, instead, passes along a double-quoted path in its system call to that script. That's sensible, because Windows file paths may contain spaces, which muck up the cmd parser.

The apparently totally clean and elegant solution to this problem is to add a simple call to the `.Trim('"')` to the bit of the PowerShell script that processes the user-supplied `-default` argument. After doing so, either of the above calls to `choose.dir()` work just as one would hope.